### PR TITLE
remote_syslog advanced config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of remote_syslog.
 
+## 0.2.0:
+
+* Implimentation of all current published remote_syslog configuration options
+
 ## 0.1.0:
 
 * Initial release of remote_syslog

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,7 +1,12 @@
 default.remote_syslog.init_style = "init"
-default.remote_syslog.conf.files = ["/var/log/*.*"]
+default.remote_syslog.conf.files = []
 default.remote_syslog.destination.host = "logs.papertrailapp.com"
 default.remote_syslog.destination.port = 12345
+default.remote_syslog.hostname = node.hostname
+default.remote_syslog.exclude_files = []
+default.remote_syslog.parse_fields = nil
+default.remote_syslog.prepend = nil
+default.remote_syslog.exclude_patterns = []
 
 # Unused
 default.remote_syslog.tcp = false

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,5 +3,5 @@ maintainer_email "support@bluebox.net"
 license          "Apache 2.0"
 description      "Installs/Configures remote_syslog"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.1.0"
+version          "0.2.0"
 name             "remote_syslog"

--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -19,8 +19,15 @@ template "/etc/log_files.yml" do
   owner "root"
   group "root"
   mode  "0644"
+  notifies :restart, "service[remote_syslog]"
+  variables :yaml => {
+              'files'            => node.remote_syslog.conf.files,
+              'exclude_files'    => node.remote_syslog.exclude_files,
+              'hostname'         => node.remote_syslog.hostname,
+              'parse_fields'     => node.remote_syslog.parse_fields,
+              'prepend'          => node.remote_syslog.prepend,
+              'exclude_patterns' => node.remote_syslog.exclude_patterns,
+              'destination'      => node.remote_syslog.destination
+            }.to_yaml(:SortKeys => true).split("\n").map{|l| l.gsub(/ \!ruby.*$/, "").gsub(/---/, "")}.join("\n")
 
-  # TODO make this a .to_yaml, issue with getting extra data
-  variables :files       => node.remote_syslog.conf.files,
-            :destination => node.remote_syslog.destination
 end

--- a/templates/default/log_files.erb
+++ b/templates/default/log_files.erb
@@ -1,8 +1,1 @@
-files:
-<% @files.each do |file| %>
-  - <%= file %>
-<% end %>
-destination:
-<% @destination.each do |option,value| %>
-  <%= option %>: <%= value %>
-<% end %>
+<%= @yaml %>


### PR DESCRIPTION
I've done the following:
- Version bump in `metadata.rb`
- `CHANGELOG.md` entry
- Added additional config as attributes as per https://github.com/papertrail/remote_syslog/blob/master/examples/log_files.yml.example.advanced
- Refactored the `log_files.yml` template variables to be a `.to_yaml` and updated the template to match.

Works for me, I put in:

``` json
"default_attributes": {
  "remote_syslog": {
    "init_style": "init",
    "destination": {
      "host": "logs.papertrailapp.com",
      "port": "12345"
    },
    "conf": {
      "files": [
        "/var/log/*.*",
        "/var/log/nginx/*.log",
        "/var/log/php-fpm.log"
      ] 
    }
  }
}
```

and get out: 

``` yaml
$ cat /etc/log_files.yml 

files:
- /var/log/*.*
- /var/log/nginx/*.log
- /var/log/php-fpm.log
exclude_files:
hostname: the-servers-name
parse_fields: 
prepend: 
exclude_patterns:
destination:
  host: logs.papertrailapp.com
  port: '12345'
```
